### PR TITLE
Change oldest non-EOL (safety) Ubuntu from focal to jammy

### DIFF
--- a/.github/workflows/debuntu_docker_images.yml
+++ b/.github/workflows/debuntu_docker_images.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        base:    ['ubuntu/focal', 'ubuntu/rolling', 'debian/bookworm', 'debian/unstable']
+        base:    ['ubuntu/jammy', 'ubuntu/rolling', 'debian/bookworm', 'debian/unstable']
         mpi:     ['openmpi', 'mpich']
         variant: ['mini', 'all', 'pdi']
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ With the following parameters:
 * `distribution`/`version`:
   - `debian/oldstable`: the image is based on the oldest version of Debian GNU Linux supported by PDI: `oldstable`
   - `debian/unstable`: the image is based on the Debian GNU Linux `unstable`
-  - `ubuntu/focal`: the image is based on Ubuntu `focal fossa`
+  - `ubuntu/jammy`: the image is based on Ubuntu `jammy jellyfish`
   - `ubuntu/rolling`: the image is based on Ubuntu latest release
 * `mpi`:
   - `mpich`: using mpich implementation of MPI,


### PR DESCRIPTION
Change oldest non-EOL (safety) Ubuntu from focal fossa to jammy jellyfish (20.04 to 22.04)