### PR TITLE
fix #28, update external action to nodejs24

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -80,10 +80,10 @@ runs:
       fi
       touch docker_image_step_SETUP_ALREADY_DONE
   - if: "${{ steps.setup.outputs.done != 'true' }}"
-    uses: docker/login-action@v3
+    uses: docker/login-action@v4
     with: { registry: "ghcr.io",  username: "${{ github.actor }}", password: "${{ inputs.GITHUB_TOKEN }}" }
   - if: "${{ steps.setup.outputs.done != 'true' }}"
-    uses: docker/setup-buildx-action@v3
+    uses: docker/setup-buildx-action@v4
   - id: info
     shell: bash
     run: |
@@ -100,7 +100,7 @@ runs:
       sudo mkswap /swapfile
       sudo swapon /swapfile
   - if: "${{ inputs.test == 'true' }}"
-    uses: docker/build-push-action@v6
+    uses: docker/build-push-action@v7
     with:
       cache-from: |
         ${{ steps.setup.outputs.cache-from }}
@@ -112,7 +112,7 @@ runs:
       target: test
     env:
       SOURCE_DATE_EPOCH: 0
-  - uses: docker/build-push-action@v6
+  - uses: docker/build-push-action@v7
     with:
       cache-from: |
         ${{ steps.setup.outputs.cache-from }}

--- a/.github/workflows/run_clang_format.yml
+++ b/.github/workflows/run_clang_format.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout context
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with: { submodules: 'recursive' }
     - name: Compute tags & version
       id: info


### PR DESCRIPTION
The error message will be solved via PR 33.
```
Check build summary support
Error: buildx failed with: ERROR: failed to build: failed to solve: failed to configure registry cache exporter: invalid reference format
```

